### PR TITLE
Update `.gitignore` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules/
+.eslintcache*
+.DS_Store*
+yarn-debug.log*
 yarn-error.log*


### PR DESCRIPTION
This brings the `.gitignore` file up-to-speed with other changes we've been making to our actively-maintained OSS projects.