### PR TITLE
Limit application of RTL rules

### DIFF
--- a/invoice.html
+++ b/invoice.html
@@ -84,16 +84,16 @@
 			}
 
 			/** RTL **/
-			.rtl {
+			.invoice-box.rtl {
 				direction: rtl;
 				font-family: Tahoma, 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif;
 			}
 
-			.rtl table {
+			.invoice-box.rtl table {
 				text-align: right;
 			}
 
-			.rtl table tr td:nth-child(2) {
+			.invoice-box.rtl table tr td:nth-child(2) {
 				text-align: left;
 			}
 		</style>


### PR DESCRIPTION
This more strictly applies the RTL CSS rules so that they don't bleed unexpectedly into other elements.